### PR TITLE
Add main entrypoint for FableForge

### DIFF
--- a/src/fableforge/main.py
+++ b/src/fableforge/main.py
@@ -342,8 +342,13 @@ def delete_character():
             print("\033[91mInvalid Name. Returning to the main menu.\033[0m")
     input("\n\033[93mPress Enter to continue...\033[0m")
 
-if __name__ == "__main__":
+def main():
+    """Entry point for the FableForge command line interface."""
     setup_logging()
     db_manager = DatabaseManager()
     db_manager.initialize_tables()
     main_menu()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a `main()` function in `src/fableforge/main.py`
- use `main()` as the CLI entry point

## Testing
- `python -m compileall -q .`
- `python - <<'PY'
import sys
sys.path.insert(0, 'src')
import fableforge.main as m
print('has main:', hasattr(m, 'main'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685ec56e2d3c832cbc6cda8caf3a01b0