### PR TITLE
Add basic pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,18 @@ Welcome to **FableForge**, a Python-based, text-driven adventure inspired by Dun
 1. Clone the repository or copy the script.
 2. From the project root, launch the game module with Python:
 
-   ```bash
-   python -m fableforge.main
-   ```
+```bash
+python -m fableforge.main
+```
+
+### 🧪 Running Tests
+
+Install the development extras and run pytest:
+
+```bash
+pip install -e .[dev]       # install with pytest
+pytest                      # run tests
+```
 
 ### 🖍️ Logging
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     # "rich>=13.0",          # example of a console library
 ]
 
+[project.optional-dependencies]
+dev = ["pytest"]
+
 # Source layout
 [tool.setuptools]
 package-dir = { "" = "src" }          # tells setuptools that packages live in src/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure the src/ directory is on the import path for tests
+root = Path(__file__).resolve().parents[1]
+src = root / "src"
+if str(src) not in sys.path:
+    sys.path.insert(0, str(src))

--- a/tests/test_character_creator.py
+++ b/tests/test_character_creator.py
@@ -1,0 +1,22 @@
+from fableforge import main
+from fableforge.main import CharacterCreator
+
+
+def test_select_class(monkeypatch):
+    monkeypatch.setattr(main, "clear_console", lambda: None)
+    inputs = iter(["Wizard"])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    assert CharacterCreator.select_class() == "Wizard"
+
+
+def test_random_stats():
+    stats = CharacterCreator.random_stats()
+    assert set(stats.keys()) == {
+        "strength",
+        "dexterity",
+        "intelligence",
+        "charisma",
+        "wisdom",
+        "constitution",
+    }
+    assert all(8 <= v <= 18 for v in stats.values())

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -1,0 +1,46 @@
+import sqlite3
+from fableforge.database_manager import DatabaseManager
+
+
+def make_db(tmp_path):
+    db_file = tmp_path / "test.db"
+    manager = DatabaseManager()
+    manager.db_name = str(db_file)
+    manager.initialize_tables()
+    return manager
+
+
+def test_initialize_tables(tmp_path):
+    manager = make_db(tmp_path)
+    with sqlite3.connect(manager.db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cursor.fetchall()}
+    assert {"characters", "quests", "inventory"}.issubset(tables)
+
+
+def test_inventory_methods(tmp_path):
+    manager = make_db(tmp_path)
+    with sqlite3.connect(manager.db_name) as conn:
+        conn.execute(
+            """
+            INSERT INTO characters (
+                id, name, race, class, strength, dexterity, intelligence,
+                charisma, wisdom, constitution, health, experience
+            ) VALUES (1, 'Hero', 'Human', 'Fighter', 10,10,10,10,10,10,100,0)
+            """
+        )
+        conn.commit()
+
+    manager.add_item(1, "Sword", 1)
+    manager.add_item(1, "Sword", 2)
+    items = manager.get_inventory(1)
+    assert ("Sword", 3) in items
+
+    manager.remove_item(1, "Sword", 1)
+    items = manager.get_inventory(1)
+    assert ("Sword", 2) in items
+
+    manager.remove_item(1, "Sword", 2)
+    items = manager.get_inventory(1)
+    assert items == []

--- a/tests/test_main_menu.py
+++ b/tests/test_main_menu.py
@@ -1,0 +1,16 @@
+import builtins
+from fableforge import main
+
+
+def test_main_menu_exit(monkeypatch):
+    monkeypatch.setattr(main, "clear_console", lambda: None)
+    monkeypatch.setattr(main, "exiting", lambda: (_ for _ in ()).throw(SystemExit))
+    inputs = iter(["3"])
+    monkeypatch.setattr("builtins.input", lambda *_: next(inputs))
+    try:
+        main.main_menu()
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError("SystemExit not raised")
+


### PR DESCRIPTION
## Summary
- set up pytest as a dev extra
- document installing and running tests
- add pytest configuration and tests for database manager and character creator
- include smoke test for the main menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686046ab930c832caeb2f33ffbfd6392